### PR TITLE
Problem with account limit - fixed

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -44,25 +44,9 @@ static inline void print_debug(account_name receiver, const action_trace& ar) {
 inline void apply_context::change_any_resource_limits_impl( const account_name& acc, int64_t ram, int64_t net, int64_t cpu, bool is_distribution )const
 {
    auto& resource_limit_mgr = control.get_mutable_resource_limits_manager();
-   int64_t ram_bytes = 0;
-   int64_t net_weight = 0;
-   int64_t cpu_weight = 0;
 
-   resource_limit_mgr.get_account_limits( acc, ram_bytes, net_weight, cpu_weight );
-   ram_bytes += ram;
-   net_weight += net;
-   cpu_weight += cpu;
-
-   if( is_distribution )
-   {
-    if (resource_limit_mgr.set_distribution_account_limits( acc, ram_bytes, net_weight, cpu_weight ))
-        trx_context.validate_ram_usage.insert( acc );
-   }
-   else
-   {
-    if (resource_limit_mgr.set_account_limits( acc, ram_bytes, net_weight, cpu_weight ))
-        trx_context.validate_ram_usage.insert( acc );
-   }
+   if( resource_limit_mgr.change_account_limits( acc, ram, net, cpu, is_distribution ) )
+      trx_context.validate_ram_usage.insert( acc );
 }
 
 inline void apply_context::change_distribution_resource_limits( const account_name& acc, int64_t ram, int64_t net, int64_t cpu )const {

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -61,7 +61,7 @@ namespace eosio { namespace chain { namespace resource_limits {
          void verify_account_ram_usage( const account_name accunt )const;
 
          /// set_account_limits returns true if new ram_bytes limit is more restrictive than the previously set one
-         bool set_distribution_account_limits( const account_name& account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight);
+         bool change_account_limits( const account_name& account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight, bool is_distribution );
          bool set_account_limits( const account_name& account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight);
          void enable_unstake_mode_distribution_resource_rewards( account_name account );
          /** Allows to retrieve amount of resources associated to given account by rewarding process performed during distribution period.
@@ -109,7 +109,10 @@ namespace eosio { namespace chain { namespace resource_limits {
          chainbase::database& _db;
 
          bool get_any_account_data( const account_name& account, int64_t& ram_bytes, int64_t& net_weight, int64_t& cpu_weight, bool is_distribution ) const;
-         bool set_any_account_limits_impl( const account_name& account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight, bool is_distribution );
+
+         const resource_limits_object& find_or_create_pending_limits( const account_name& account );
+         bool change_any_account_limits_impl( const account_name& account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight, bool is_distribution );
+         bool set_any_account_limits_impl( const account_name& account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight );
 
          template <typename TObjectConverter, typename TProcessor>
          void process_userres(const account_name& lowerBound, const account_name& upperBound, TProcessor processor) const;

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -154,23 +154,26 @@ namespace eosio { namespace chain { namespace resource_limits {
       int64_t distribution_cpu_weight = 0;
       int64_t distribution_ram_bytes = 0;
 
-      void set_resource_limits( int64_t _ram_bytes, int64_t _net_weight, int64_t _cpu_weight, bool is_distribution )
+      void change_resource_limits( int64_t _ram_bytes, int64_t _net_weight, int64_t _cpu_weight, bool is_distribution )
+      {
+        ram_bytes += _ram_bytes;
+        net_weight += _net_weight;
+        cpu_weight += _cpu_weight;
+
+        if( is_distribution )
+        {
+           EOS_ASSERT( _ram_bytes >= 0 && _net_weight >= 0 && _cpu_weight >= 0, resource_limit_exception, "during distribution only positive rewards are allowed" );
+           distribution_ram_bytes += _ram_bytes;
+           distribution_net_weight += _net_weight;
+           distribution_cpu_weight += _cpu_weight;
+        }
+      }
+
+      void set_resource_limits( int64_t _ram_bytes, int64_t _net_weight, int64_t _cpu_weight )
       {
         ram_bytes = _ram_bytes;
         net_weight = _net_weight;
         cpu_weight = _cpu_weight;
-
-        if( is_distribution )
-        {
-            if( _ram_bytes > distribution_ram_bytes )
-              distribution_ram_bytes = _ram_bytes;
-
-            if( _net_weight > distribution_net_weight )
-              distribution_net_weight = _net_weight;
-
-            if( _cpu_weight > distribution_cpu_weight )
-              distribution_cpu_weight = _cpu_weight;
-        }
       }
    };
 


### PR DESCRIPTION
**Change Description**

Fixed account limits storage to avoid improper setting of stake (BEOS) reward after BEOS distribution finished. This lead to fail chain_pugin::get_account which queries for given account resources and also verifies blockchain sanity.

**Consensus Changes**
None
**API Changes**
None
**Documentation Additions**
None